### PR TITLE
test: fix tests on PHP 7

### DIFF
--- a/tests/Integration/ClientMiddlewareTest.php
+++ b/tests/Integration/ClientMiddlewareTest.php
@@ -139,9 +139,18 @@ final class ClientMiddlewareTest extends TestCase
 
         $client->ping();
 
-        $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage('Error writing request: fwrite(): Send of 15 bytes failed with errno=32 Broken pipe');
-        $client->ping();
+        try {
+            $client->ping();
+        } catch(CommunicationFailed $e) {
+            self::assertEqualsIgnoringCase(
+                'Error writing request: fwrite(): Send of 15 bytes failed with errno=32 Broken pipe',
+                $e->getMessage()
+            );
+
+            return;
+        }
+
+        self::fail();
     }
 
     private static function createBrokenConnectionMiddleware() : Middleware

--- a/tests/Integration/Connection/ConnectionTest.php
+++ b/tests/Integration/Connection/ConnectionTest.php
@@ -206,11 +206,12 @@ final class ConnectionTest extends TestCase
             $connection->open();
             self::fail('Connection not established');
         } catch (CommunicationFailed $e) {
-            self::assertSame(
+            self::assertEqualsIgnoringCase(
                 sprintf('Error reading greeting: ' .
                     'stream_socket_client(): Unable to connect to %s ' .
                     '(Connection refused)', $uri)
-                , $e->getMessage());
+                , $e->getMessage()
+            );
             // At that point the connection was successfully established,
             // but the greeting message was not read
         }

--- a/tests/Integration/Connection/ParseGreetingTest.php
+++ b/tests/Integration/Connection/ParseGreetingTest.php
@@ -38,11 +38,12 @@ final class ParseGreetingTest extends TestCase
         try {
             $client->ping();
         } catch (CommunicationFailed $e) {
-            self::assertSame(
+            self::assertEqualsIgnoringCase(
                 sprintf("Error reading greeting: " .
                     "stream_socket_client(): Unable to connect to %s " .
                     "(Connection refused)", $uri),
-                $e->getMessage());
+                $e->getMessage()
+            );
 
             return;
         } catch (\RuntimeException $e) {

--- a/tests/Integration/Connection/ReadTest.php
+++ b/tests/Integration/Connection/ReadTest.php
@@ -43,14 +43,20 @@ final class ReadTest extends TestCase
 
         $client = $clientBuilder->build();
 
-        $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage(
-            \sprintf('Error reading greeting: ' .
-                     'stream_socket_client(): Unable to connect to %s ' .
-                     '(Connection refused)', $uri)
-        );
+        try {
+            $client->ping();
+        } catch(CommunicationFailed $e) {
+            self::assertEqualsIgnoringCase(
+                \sprintf('Error reading greeting: ' .
+                    'stream_socket_client(): Unable to connect to %s ' .
+                    '(Connection refused)', $uri),
+                $e->getMessage()
+            );
 
-        $client->ping();
+            return;
+        }
+
+        self::fail();
     }
 
     public function testUnableToReadResponseLength() : void
@@ -67,14 +73,20 @@ final class ReadTest extends TestCase
 
         $client = $clientBuilder->build();
 
-        $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage(
-            \sprintf('Error reading response length: ' .
-                'stream_socket_client(): Unable to connect to %s ' .
-                '(Connection refused)', $uri)
-        );
+        try {
+            $client->ping();
+        } catch(CommunicationFailed $e) {
+            self::assertEqualsIgnoringCase(
+                \sprintf('Error reading response length: ' .
+                    'stream_socket_client(): Unable to connect to %s ' .
+                    '(Connection refused)', $uri),
+                $e->getMessage()
+            );
 
-        $client->ping();
+            return;
+        }
+
+        self::fail();
     }
 
     public function testReadResponseLengthTimedOut() : void
@@ -112,14 +124,20 @@ final class ReadTest extends TestCase
 
         $client = $clientBuilder->build();
 
-        $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage(
-            \sprintf('Error reading response: ' .
-                'stream_socket_client(): Unable to connect to %s ' .
-                '(Connection refused)', $uri)
-        );
+        try {
+            $client->ping();
+        } catch(CommunicationFailed $e) {
+            self::assertEqualsIgnoringCase(
+                \sprintf('Error reading response: ' .
+                    'stream_socket_client(): Unable to connect to %s ' .
+                    '(Connection refused)', $uri),
+                $e->getMessage()
+            );
 
-        $client->ping();
+            return;
+        }
+
+        self::fail();
     }
 
     public function testSocketReadTimedOut() : void


### PR DESCRIPTION
Changes to tests introduced in #89 make them fail on PHP 7.x. This patch fixes failing tests.